### PR TITLE
Use correct options object for iconFont*

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ elixir.extend('fonts', function(src, output, options) {
 
     new Task('fonts', function() {
         return gulp.src(src)
-            .pipe(iconFontCss(config.css))
-            .pipe(iconFont(config.font))
+            .pipe(iconFontCss(options.css))
+            .pipe(iconFont(options.font))
             .pipe(gulp.dest(output));
     }).watch(src);
 


### PR DESCRIPTION
extendOptions extends its second parameter with the entries of the first one if the entry is not set.
But instead of the options object, the config one was used. So it always used the default values an ignored the configuration values.